### PR TITLE
Add support for retrieving credits and memberships

### DIFF
--- a/lib/mariana_api/admin_api/resources/credits.rb
+++ b/lib/mariana_api/admin_api/resources/credits.rb
@@ -1,0 +1,15 @@
+module MarianaApi::AdminApi::Resources
+  class Credits
+    def initialize(http_client)
+      @http_client = http_client
+    end
+
+    def list(params = {})
+      @http_client.get('/api/credits', params: params).force
+    end
+
+    def read(id, params = {})
+      @http_client.get("/api/credits/#{id}", params: params)
+    end
+  end
+end

--- a/lib/mariana_api/admin_api/resources/memberships.rb
+++ b/lib/mariana_api/admin_api/resources/memberships.rb
@@ -1,0 +1,15 @@
+module MarianaApi::AdminApi::Resources
+  class Memberships
+    def initialize(http_client)
+      @http_client = http_client
+    end
+
+    def list(params = {})
+      @http_client.get('/api/memberships', params: params).force
+    end
+
+    def read(id, params = {})
+      @http_client.get("/api/memberships/#{id}", params: params)
+    end
+  end
+end


### PR DESCRIPTION
Testing...

```
[3] pry(main)> CLIENT.admin_api_client.resources.memberships.list.map { |l| l[:attributes][:name] }
=> ["Standard Membership", "Premium Membership"]
[4] pry(main)> CLIENT.admin_api_client.resources.credits.list.map { |l| l[:attributes][:name] }
=> ["Standard Credit", "Premium Credit", "Standard Credit - New York", "Premium Credit - New York"]
```