### PR TITLE
Follow 3xx redirects for unauthenticated GETs before parsing JSON

### DIFF
--- a/lib/mariana_api/client.rb
+++ b/lib/mariana_api/client.rb
@@ -11,6 +11,7 @@ require 'securerandom'
 module MarianaApi
   class Client
     REQUEST_TIMEOUT = 90
+    REDIRECT_LIMIT = 5
 
     attr_accessor :logger, :log_http_transactions, :subdomain, :on_token_refresh
 
@@ -165,7 +166,9 @@ module MarianaApi
         auth_type: :auto,
         retry_limit: 0,
         retry_delay: 2,
-        retry_attempt: 0
+        retry_attempt: 0,
+        redirect_limit: REDIRECT_LIMIT,
+        redirect_attempt: 0
       }.merge(opts)
 
       auth_type = opts[:auth_type]
@@ -220,6 +223,35 @@ module MarianaApi
           return api_request(method, uri.to_s, opts)
         end
         raise
+      end
+
+      # Net::HTTP does not follow redirects on its own, and a 3xx response comes
+      # back with an empty body that would blow up JSON.parse ("unexpected token
+      # at ''"). Mariana Tek issues these for alias subdomains that point at the
+      # canonical one (e.g. fusionfitness -> sweatlabfitness), so follow the
+      # Location header before parsing -- but only for unauthenticated GETs.
+      # We never re-issue an authenticated request to a redirect target (so a
+      # bearer token can't be leaked, regardless of host) and never replay a
+      # non-GET request against a new location; those raise instead.
+      if response_code >= 300 && response_code < 400 && response['location']
+        unless method == :get && token.nil?
+          raise "Refusing to follow #{response_code} redirect for #{method} #{uri} " \
+                "to #{response['location']} (authenticated or non-GET request)"
+        end
+
+        if opts[:redirect_attempt] >= opts[:redirect_limit]
+          raise "Exceeded redirect limit (#{opts[:redirect_limit]}) for #{method} #{uri}"
+        end
+
+        # The Location carries the full target URL (path + query); don't re-apply
+        # the original query params on top of it.
+        redirect_uri = URI.join(uri.to_s, response['location'])
+        redirect_opts = opts.dup
+        redirect_opts[:redirect_attempt] += 1
+        redirect_opts.delete(:query)
+
+        @logger.info("Following redirect (#{response_code}) to #{redirect_uri}")
+        return api_request(method, redirect_uri.to_s, redirect_opts)
       end
 
       JSON.parse(response.body, symbolize_names: true)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -45,6 +45,46 @@ describe 'Client' do
       expect(stub).to have_been_requested.times(3)
     end
 
+    it 'follows redirects for unauthenticated GET requests' do
+      redirect = stub_request(:get, 'https://test.marianatek.com/api/tenant_brands?page_size=100')
+                 .to_return(status: 301, headers: { 'Location' => 'https://canonical.marianatek.com/api/tenant_brands?page_size=100' })
+
+      target = stub_request(:get, 'https://canonical.marianatek.com/api/tenant_brands?page_size=100')
+               .with { |req| !req.headers.key?('Authorization') }
+               .to_return(body: '{}')
+
+      @client.get('/api/tenant_brands', auth_type: :none)
+
+      expect(redirect).to have_been_requested
+      expect(target).to have_been_requested
+    end
+
+    it 'does not follow redirects for authenticated requests' do
+      redirect = stub_request(:get, 'https://test.marianatek.com/api/users?page_size=100')
+                 .to_return(status: 301, headers: { 'Location' => 'https://canonical.marianatek.com/api/users?page_size=100' })
+
+      expect { @client.get('/api/users', auth_type: :api_key) }
+        .to raise_error(/Refusing to follow/)
+      expect(redirect).to have_been_requested
+    end
+
+    it 'does not follow redirects for non-GET requests' do
+      redirect = stub_request(:post, 'https://test.marianatek.com/api/orders')
+                 .to_return(status: 301, headers: { 'Location' => 'https://canonical.marianatek.com/api/orders' })
+
+      expect { @client.post('/api/orders', body: '{}', auth_type: :none) }
+        .to raise_error(/Refusing to follow/)
+      expect(redirect).to have_been_requested
+    end
+
+    it 'raises when the redirect limit is exceeded' do
+      stub_request(:get, 'https://test.marianatek.com/api/tenant_brands?page_size=100')
+        .to_return(status: 301, headers: { 'Location' => 'https://test.marianatek.com/api/tenant_brands?page_size=100' })
+
+      expect { @client.get('/api/tenant_brands', auth_type: :none) }
+        .to raise_error(/Exceeded redirect limit/)
+    end
+
     it 'retrieves a paginated dataset with includes' do
       stub_request(:get, 'https://test.marianatek.com/api/locations?page_size=10&include=region')
         .to_return(body: File.read('spec/fixtures/locations-page-1.json'))


### PR DESCRIPTION
## Problem

For some tenants, Mariana Tek's API responds with a **redirect** instead of data — an alias subdomain pointing at the canonical one (e.g. `fusionfitness.marianatek.com/api/tenant_brands` → `sweatlabfitness.marianatek.com/api/tenant_brands`). The 3xx comes back with an **empty body**.

`api_request` in `client.rb` uses a plain `Net::HTTP` client, which does **not** follow redirects, and only special-cases 429/5xx for retries. So the empty redirect body went straight to `JSON.parse`, raising:

```
JSON::ParserError: unexpected token at ''
```

This surfaced via `Tenant#logo_url!`, whose `tenant_brands` call is **unauthenticated** (`auth_type: :none`).

## Fix

`api_request` now follows 3xx responses via the `Location` header before parsing, scoped conservatively:

- **Only unauthenticated GET requests are followed.** This covers the reported `tenant_brands` case.
- **Authenticated requests are never re-issued to a redirect target** — so a bearer token can never be leaked to a redirect host, regardless of domain.
- **Non-GET requests are never replayed** against a new location (avoids re-submitting mutations).
- Authenticated/non-GET redirects raise a **clear, actionable error** naming the `Location` target instead of the cryptic JSON parse error.
- Redirect following is capped (`REDIRECT_LIMIT = 5`) to avoid loops, and uses the `Location` URL as-is (it carries the full path + query).

## Tests

Added specs: follows an unauthenticated GET redirect (no auth header re-sent), refuses to follow an authenticated request, refuses to follow a non-GET request, and raises when the redirect limit is exceeded.

> Note: the pre-existing `#get_user_token` spec failure is unrelated to this change (fails on `master` as well).

## Follow-up (separate repo)

Bump the gem revision in `mariana-tools`' `Gemfile.lock` via `bundle update mariana_api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)